### PR TITLE
Add extraRunParams for hooks, commands, and crons

### DIFF
--- a/disco/endpoints/cgi.py
+++ b/disco/endpoints/cgi.py
@@ -226,6 +226,7 @@ async def request_cgi(
         project_name,
         service_name,
     )
+    extra_run_params = disco_file.services[service_name].extra_run_params
     await docker.run(
         image=image,
         project_name=project_name,
@@ -237,6 +238,13 @@ async def request_cgi(
         stdin=content,
         stdout=stdout,
         stderr=stderr,
+        extra_params=[
+            param.strip()
+            for param in extra_run_params.split(" ")
+            if len(param.strip()) > 0
+        ]
+        if extra_run_params is not None
+        else None,
     )
     if len(cgi_err) > 0:
         log.info("Received stderr from CGI: %s", cgi_err)

--- a/disco/utils/asyncworker.py
+++ b/disco/utils/asyncworker.py
@@ -205,6 +205,16 @@ class ProjectCron(Cron):
             self.next = self.cron.get_next(datetime)
         self.schedule = schedule
         self.timeout = disco_file.services[self.service_name].timeout
+        extra_run_params = disco_file.services[self.service_name].extra_run_params
+        self.extra_params = (
+            [
+                param.strip()
+                for param in extra_run_params.split(" ")
+                if len(param.strip()) > 0
+            ]
+            if extra_run_params is not None
+            else None
+        )
 
     async def run(self) -> None:
         async def log_stdout(stdout: str) -> None:
@@ -227,6 +237,7 @@ class ProjectCron(Cron):
             timeout=self.timeout,
             stdout=log_stdout,
             stderr=log_stderr,
+            extra_params=self.extra_params,
         )
 
     def schedule_next(self) -> None:

--- a/disco/utils/commandruns.py
+++ b/disco/utils/commandruns.py
@@ -81,6 +81,7 @@ def create_command_run(
 
         name = f"{project_name}-run.{run_number}"
         try:
+            extra_run_params = disco_file.services[service].extra_run_params
             await docker.run(
                 image=image,
                 project_name=project_name,
@@ -92,6 +93,13 @@ def create_command_run(
                 timeout=timeout,
                 stdout=log_output,
                 stderr=log_output,
+                extra_params=[
+                    param.strip()
+                    for param in extra_run_params.split(" ")
+                    if len(param.strip()) > 0
+                ]
+                if extra_run_params is not None
+                else None,
             )
         except TimeoutError:
             await log_output(f"Timed out after {timeout} seconds\n")

--- a/disco/utils/deploymentflow.py
+++ b/disco/utils/deploymentflow.py
@@ -396,6 +396,13 @@ async def run_hook_deploy_start_before(
             timeout=service.timeout,
             stdout=log_output,
             stderr=log_output,
+            extra_params=[
+                param.strip()
+                for param in service.extra_run_params.split(" ")
+                if len(param.strip()) > 0
+            ]
+            if service.extra_run_params is not None
+            else None,
         )
 
 
@@ -456,6 +463,13 @@ async def run_hook_deploy_start_after(
             timeout=service.timeout,
             stdout=log_output,
             stderr=log_output,
+            extra_params=[
+                param.strip()
+                for param in service.extra_run_params.split(" ")
+                if len(param.strip()) > 0
+            ]
+            if service.extra_run_params is not None
+            else None,
         )
 
 

--- a/disco/utils/discofile.py
+++ b/disco/utils/discofile.py
@@ -59,6 +59,10 @@ class Service(BaseModel):
         None,
         alias="extraSwarmParams",
     )
+    extra_run_params: str | None = Field(
+        None,
+        alias="extraRunParams",
+    )
 
 
 class DiscoFile(BaseModel):

--- a/disco/utils/docker.py
+++ b/disco/utils/docker.py
@@ -1017,10 +1017,13 @@ async def run(
     stdin: AsyncGenerator[bytes, None] | None = None,
     workdir: str | None = None,
     timeout: int = 600,
+    extra_params: list[str] | None = None,
 ) -> None:
     log.info("Docker run %s (%s)", name, image)
     try:
         more_args = []
+        if extra_params is not None:
+            more_args.extend(extra_params)
         for var_name, var_value in env_variables:
             more_args.append("--env")
             more_args.append(f"{var_name}={var_value}")


### PR DESCRIPTION
## Problem

`extraSwarmParams` works great for long-running services (`docker service create`), but hooks (`hook:deploy:start:before`, `hook:deploy:start:after`), `disco run` commands, cron jobs, and CGI handlers use `docker container create` instead — and they don't support any extra Docker parameters.

This becomes a problem when containers need to reach services on the Docker host. For example, if you run a database proxy (like ProxySQL or PgBouncer) on the host machine, services can reach it via `--host host.docker.internal:host-gateway` in `extraSwarmParams`. But deploy hooks that need to run database migrations can't reach the proxy at all, because hooks don't support extra params.

We ran into this during a database migration: our Prisma migration hook (`npx prisma migrate deploy`) needed to connect to a database proxy on the host, but the hook container couldn't resolve `host.docker.internal`. We had to remove the migration hook from `disco.json` entirely and run migrations manually as a workaround.

## Solution

Add a new `extraRunParams` field to the service definition in `disco.json`. This is passed as extra arguments to `docker container create` for:

- `hook:deploy:start:before`
- `hook:deploy:start:after`
- `disco run` commands
- Cron jobs
- CGI handlers

This is separate from `extraSwarmParams` because `docker service create` and `docker container create` accept different flags (e.g. `--host` vs `--add-host`).

## Example

```json
{
  "services": {
    "web": {
      "port": 8000,
      "extraSwarmParams": "--host host.docker.internal:host-gateway"
    },
    "hook:deploy:start:before": {
      "type": "command",
      "command": "npx prisma migrate deploy",
      "extraRunParams": "--add-host host.docker.internal:host-gateway"
    }
  }
}
```

## Changes

- **`discofile.py`**: Add `extraRunParams` field to Service model
- **`docker.py`**: Add `extra_params` argument to `run()` function
- **`deploymentflow.py`**: Pass `extraRunParams` to both before/after deploy hooks
- **`commandruns.py`**: Pass `extraRunParams` to `disco run` commands
- **`asyncworker.py`**: Pass `extraRunParams` to cron jobs
- **`cgi.py`**: Pass `extraRunParams` to CGI handlers