### PR TITLE
Add --no-cache flag for deployments

### DIFF
--- a/disco/alembic/versions/a1b2c3d4e5f6_add_no_cache.py
+++ b/disco/alembic/versions/a1b2c3d4e5f6_add_no_cache.py
@@ -1,0 +1,32 @@
+"""Add no_cache column to deployments
+
+Revision ID: a1b2c3d4e5f6
+Revises: d8adabff2804
+Create Date: 2026-03-25 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "a1b2c3d4e5f6"
+down_revision = "d8adabff2804"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("deployments", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "no_cache",
+                sa.Boolean(),
+                nullable=False,
+                server_default="0",
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("deployments", schema=None) as batch_op:
+        batch_op.drop_column("no_cache")

--- a/disco/endpoints/deployments.py
+++ b/disco/endpoints/deployments.py
@@ -59,6 +59,7 @@ def deployments_get(
 class DeploymentRequestBody(BaseModel):
     commit: str = Field("_DEPLOY_LATEST_", pattern=r"^\S+$")
     disco_file: DiscoFile | None = Field(None, alias="discoFile")
+    no_cache: bool = Field(False, alias="noCache")
 
     @model_validator(mode="after")
     def commit_or_disco_file_required(self) -> "DeploymentRequestBody":
@@ -91,6 +92,7 @@ async def deployments_post(
         commit_hash=req_body.commit if req_body.disco_file is None else None,
         disco_file=req_body.disco_file,
         by_api_key=api_key,
+        no_cache=req_body.no_cache,
     )
     background_tasks.add_task(enqueue_deployment, deployment.id)
     return {

--- a/disco/models/deployment.py
+++ b/disco/models/deployment.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
-from sqlalchemy import ForeignKey, Integer, String, Unicode
+from sqlalchemy import Boolean, ForeignKey, Integer, String, Unicode
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 if TYPE_CHECKING:
@@ -65,6 +65,12 @@ class Deployment(Base):
     task_id: Mapped[str | None] = mapped_column(
         String(32),
         nullable=True,
+    )
+    no_cache: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        server_default="0",
+        nullable=False,
     )
 
     project: Mapped[Project] = relationship(

--- a/disco/utils/deploymentflow.py
+++ b/disco/utils/deploymentflow.py
@@ -66,6 +66,7 @@ class DeploymentInfo:
     disco_host: str
     env_variables: list[tuple[str, str]]
     scale: Mapping[str, int]
+    no_cache: bool
 
     @staticmethod
     async def from_deployment(
@@ -96,6 +97,7 @@ class DeploymentInfo:
                 (env_var.name, decrypt(env_var.value)) for env_var in env_variables
             ],
             scale=scale,
+            no_cache=deployment.no_cache,
         )
 
 
@@ -666,6 +668,7 @@ async def build_images(
             env_variables=env_variables,
             stdout=log_output,
             stderr=log_output,
+            no_cache=new_deployment_info.no_cache,
         )
     for image_name, image in new_deployment_info.disco_file.images.items():
         await log_output(f"Building image {image_name}\n")
@@ -684,6 +687,7 @@ async def build_images(
             env_variables=env_variables,
             stdout=log_output,
             stderr=log_output,
+            no_cache=new_deployment_info.no_cache,
         )
 
     return images

--- a/disco/utils/deployments.py
+++ b/disco/utils/deployments.py
@@ -45,6 +45,7 @@ async def create_deployment(
     disco_file: DiscoFile | None,
     by_api_key: ApiKey | None,
     number: int | None = None,
+    no_cache: bool = False,
 ) -> Deployment:
     if number is not None:
         if len(await project.awaitable_attrs.deployments) > 0:
@@ -72,6 +73,7 @@ async def create_deployment(
         else None,
         docker_registry=await keyvalues.get_value(dbsession, "REGISTRY"),
         by_api_key=by_api_key,
+        no_cache=no_cache,
     )
     dbsession.add(deployment)
     for env_variable in await project.awaitable_attrs.env_variables:

--- a/disco/utils/docker.py
+++ b/disco/utils/docker.py
@@ -33,6 +33,7 @@ async def build_image(
     dockerfile_path: str | None = None,
     dockerfile_str: str | None = None,
     timeout: int = 3600,
+    no_cache: bool = False,
 ) -> None:
     log.info("Building Docker image %s", image)
     assert (dockerfile_path is None) != (dockerfile_str is None)
@@ -53,9 +54,11 @@ async def build_image(
         # https://github.com/docker/buildx/issues/1881
         ("BUILDX_GIT_INFO", "0"),
     ]
+    no_cache_args = ["--no-cache"] if no_cache else []
     args = [
         "docker",
         "build",
+        *no_cache_args,
         *env_var_args,
         "--cpu-period",
         "100000",  # default


### PR DESCRIPTION
## Summary

- Adds `noCache` field to the deployment POST request body
- Persists the flag on the `Deployment` model (new `no_cache` boolean column)
- Threads the flag through `DeploymentInfo` → `build_images()` → `docker.build_image()`
- Passes `--no-cache` to `docker build` when the flag is set
- Includes Alembic migration for the new column

## Motivation

When debugging build issues or dealing with stale cached layers, there's no way to force a clean Docker build through Disco. The only workaround is SSH-ing into the server and running `docker builder prune`, which affects all projects.

This adds per-deployment cache control via `disco deploy --project <name> --no-cache`.

## Companion PR

CLI side: https://github.com/letsdiscodev/cli/pull/116

## Files changed

| File | Change |
|------|--------|
| `disco/models/deployment.py` | Add `no_cache` boolean column |
| `disco/endpoints/deployments.py` | Accept `noCache` in request body, pass to `create_deployment()` |
| `disco/utils/deployments.py` | Thread `no_cache` param through `create_deployment()` |
| `disco/utils/deploymentflow.py` | Add to `DeploymentInfo` dataclass, pass to both `build_image()` call sites |
| `disco/utils/docker.py` | Add `no_cache` param, insert `--no-cache` into docker build args |
| `disco/alembic/versions/a1b2c3d4e5f6_add_no_cache.py` | Migration to add column |

## Test plan

- [ ] Deploy with `noCache: false` (default) — should behave identically to current behavior
- [ ] Deploy with `noCache: true` — docker build output should show layers being rebuilt (no `CACHED` lines)
- [ ] Verify migration runs cleanly on existing database
- [ ] Verify existing deployments default to `no_cache = false`